### PR TITLE
Add more checks for curl, download, and crontab

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,16 +10,30 @@ if ! dpkg-query -W -f='${Status}' discord 2>/dev/null | grep -q "install ok inst
     exit 1
 fi
 
+# Check if curl is installed
+if ! dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -q "install ok installed"; then
+    echo "The 'curl' command is required but not installed. Please install it and try again."
+    exit 1
+fi
+
 # Create the installation directory if it doesn't exist
 mkdir -p "$INSTALL_DIR"
 
 # Download the main script from the GitHub repository silently
-curl -s -o "$INSTALL_DIR/misericorde.sh" "$SCRIPT_URL" >/dev/null 2>&1
+if curl -s -o "$INSTALL_DIR/misericorde.sh" "$SCRIPT_URL"; then
+    # Make the script executable
+    chmod +x "$INSTALL_DIR/misericorde.sh"
+else
+    echo "Failed to download the script. Please check your internet connection or the script URL."
+    exit 1
+fi
 
 # Make the script executable
 chmod +x "$INSTALL_DIR/misericorde.sh"
 
-# Setup crontab to run the script every hour
-(crontab -l 2>/dev/null; echo "0 * * * * $INSTALL_DIR/misericorde.sh") | crontab -
+# Setup crontab to run the script every hour, only if it doesn't exist yet
+if ! crontab -l 2>/dev/null | grep -q "0 \* \* \* \* $INSTALL_DIR/misericorde.sh"; then
+    (crontab -l 2>/dev/null; echo "0 * * * * $INSTALL_DIR/misericorde.sh") | crontab -
+fi
 
 echo "Miséricorde has been installed and will check for Discord updates every hour."


### PR DESCRIPTION
- Added a check to ensure that `curl` is installed before attempting to download the script.
- Added error handling for the script download process, displaying a failure message if the download does not succeed.
- Added a condition to check if the crontab entry already exists, preventing duplicate entries.