### PR TITLE
Enhancement: Added logic to manage crontab access using `cron.allow` and `cron.deny`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,9 +28,6 @@ else
     exit 1
 fi
 
-# Make the script executable
-chmod +x "$INSTALL_DIR/misericorde.sh"
-
 # Setup crontab to run the script every hour, only if it doesn't exist yet
 if ! crontab -l 2>/dev/null | grep -q "0 \* \* \* \* $INSTALL_DIR/misericorde.sh"; then
     (crontab -l 2>/dev/null; echo "0 * * * * $INSTALL_DIR/misericorde.sh") | crontab -

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ elif [ -f /etc/cron.allow ] && ! grep -qx "$USER" /etc/cron.allow; then
     zenity --info --title="Authentication Required" --text="This action requires elevated permissions to add your user to /etc/cron.allow. Please enter your password." --width=400   
     echo "Adding user $USER to /etc/cron.allow." 
     # Use pkexec to elevate privileges for both actions
-    pkexec bash -c "echo '$USER' >> /etc/cron.allow && chmod 0644 /etc/cron.allow"
+    pkexec bash -c "echo '$USER' >> /etc/cron.allow && chmod 0640 /etc/cron.allow"
 fi
 
 # Create the installation directory if it doesn't exist

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,9 @@ else
     exit 1
 fi
 
+# Make the script executable
+chmod +x "$INSTALL_DIR/misericorde.sh"
+
 # Setup crontab to run the script every hour, only if it doesn't exist yet
 if ! crontab -l 2>/dev/null | grep -q "0 \* \* \* \* $INSTALL_DIR/misericorde.sh"; then
     (crontab -l 2>/dev/null; echo "0 * * * * $INSTALL_DIR/misericorde.sh") | crontab -

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ elif [ -f /etc/cron.allow ] && ! grep -qx "$USER" /etc/cron.allow; then
     zenity --info --title="Authentication Required" --text="This action requires elevated permissions to add your user to /etc/cron.allow. Please enter your password." --width=400   
     echo "Adding user $USER to /etc/cron.allow." 
     # Use pkexec to elevate privileges for both actions
-    pkexec bash -c "echo '$USER' >> /etc/cron.allow && chmod 0640 /etc/cron.allow"
+    pkexec bash -c "echo '$USER' >> /etc/cron.allow && chmod 0644 /etc/cron.allow"
 fi
 
 # Create the installation directory if it doesn't exist


### PR DESCRIPTION
- Implemented checks to deny access for users listed in `/etc/cron.deny`.
- Prompt for authentication when adding users to `/etc/cron.allow` using zenity for a better user experience.
- Ensured that the `cron.allow` file has the correct permissions to allow scheduled tasks to run smoothly.