### PR TITLE
switch from cron to user systemd

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         <li>Checks if you're running the latest version of Discord.</li>
         <li>Downloads and installs the latest version if needed.</li>
         <li>Stops Discord gracefully (if running) to install updates.</li>
-        <li>Sets up a cron job to check for updates every hour.</li>
+        <li>Uses a <strong>user-level systemd timer</strong> to check for updates every 5 hours (customizable).</li>
     </ul>
 
     <h2>📥 Install Miséricorde</h2>
@@ -75,12 +75,27 @@
     <h2>🛠️ What Happens After Install?</h2>
     <ul>
         <li>The Miséricorde script is installed in your <code>~/.misericorde/</code> directory.</li>
-        <li>A cron job is set up to automatically check for Discord updates every hour.</li>
+        <li>A <strong>user-level systemd timer</strong> is set up to automatically check for Discord updates every 5 hours (default setting).</li>
         <li>It keeps Discord up-to-date without you lifting a finger.</li>
     </ul>
 
     <h2>🖥️ Supported Systems</h2>
     <p>Miséricorde is designed for <strong>Debian-based systems</strong> like Debian, Ubuntu, or Linux Mint.</p>
+
+    <h2>Customizing the Update Interval</h2>
+    <p>By default, Miséricorde checks for updates every 5 hours. To change this interval:</p>
+    <ul>
+        <li>Locate the systemd timer file in <code>~/.config/systemd/user/misericorde.timer</code></li>
+        <li>Edit the file to modify the <code>OnCalendar</code> value. For example:</li>
+        <ul>
+            <li><strong>Run every minute</strong> (for testing): <code>OnCalendar=*-*-* *:*</code></li>
+            <li><strong>Run every hour:</strong> <code>OnCalendar=hourly</code></li>
+            <li><strong>Run every day at midnight:</strong> <code>OnCalendar=*-*-* 00:00:00</code></li>
+        </ul>
+        <li>Reload and restart the timer with:</li>
+        <code>systemctl --user daemon-reload</code>
+        <code>systemctl --user restart misericorde.timer</code>
+    </ul>
 
     <h2>❓ Need Help?</h2>
     <p>If you run into any issues, feel free to visit the <a href="https://github.com/4p/misericorde" target="_blank">GitHub repository</a> for support or to report bugs.</p>

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,9 @@
 - Automatically checks if you’re running the latest version of Discord.
 - Gracefully stops Discord if it’s running to install updates.
 - Downloads and installs the latest version if needed.
-- Sets up a cron job to check for updates every hour.
+- Uses a **user-level systemd timer** to check for updates every 5 hours (customizable).
 - Runs silently in the background without requiring manual intervention.
+- No root (`sudo`) privileges required for installation or setup.
 
 ## 🔧 How It Works
 
@@ -16,7 +17,7 @@ Miséricorde takes care of the tedious update process:
 1. **Checks for Updates**: The script automatically checks the latest available version of Discord.
 2. **Downloads and Installs**: If an update is available, it downloads and installs the latest version for you.
 3. **Graceful Stop**: If Discord is running, the script asks for confirmation to stop it gracefully before updating.
-4. **Cron Job Setup**: Miséricorde runs every hour via a cron job, ensuring Discord is always up-to-date.
+4. **Systemd Timer**: Miséricorde uses a **user-level systemd timer** instead of cron to run the updater at regular intervals (default: every 5 hours).
 
 ## 📥 Installation
 
@@ -29,8 +30,12 @@ curl -s https://4p.github.io/misericorde/install.sh | bash
 ### 🛠️ What Happens After Installation?
 
 - The script is downloaded and installed in the `~/.misericorde/` directory.
-- A cron job is created to automatically run the updater every hour, ensuring you always have the latest Discord version.
+- A **user-level systemd timer** is created to automatically run the updater every 5 hours (default setting).
 - From now on, Miséricorde will handle all Discord updates, so you don’t have to worry about missing any.
+
+### No `sudo` Required! 🎉
+
+The entire installation process happens within your home directory. Systemd timers and services are set up in `~/.config/systemd/user`, so no `sudo` privileges are needed.
 
 ## 🖥️ Supported Systems
 
@@ -41,6 +46,46 @@ Miséricorde is specifically designed for **Debian-based systems**, including:
 - Other Debian derivatives
 
 If you’re unsure if your system is supported, Miséricorde will detect this and notify you before proceeding.
+
+## Customizing the Update Interval
+
+By default, Miséricorde runs every **5 hours**. To change this interval:
+1. Edit the systemd timer file:
+   ```bash
+   nano ~/.config/systemd/user/misericorde.timer
+   ```
+2. Modify the `OnCalendar` value to your desired schedule. For example:
+   - Run every minute (for testing): `OnCalendar=*-*-* *:*`
+   - Run every hour: `OnCalendar=hourly`
+   - Run every day at midnight: `OnCalendar=*-*-* 00:00:00`
+   - For detailed scheduling options, refer to the [systemd.timer documentation](https://www.freedesktop.org/software/systemd/man/systemd.timer.html).
+3. Reload systemd and restart the timer:
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user restart misericorde.timer
+   ```
+
+## Uninstalling Miséricorde
+
+If you ever need to uninstall Miséricorde, follow these steps:
+1. Stop and disable the systemd timer:
+   ```bash
+   systemctl --user stop misericorde.timer
+   systemctl --user disable misericorde.timer
+   ```
+2. Remove the service and timer files:
+   ```bash
+   rm ~/.config/systemd/user/misericorde.service
+   rm ~/.config/systemd/user/misericorde.timer
+   ```
+3. Reload systemd to apply the changes:
+   ```bash
+   systemctl --user daemon-reload
+   ```
+4. Optionally, delete the installation directory:
+   ```bash
+   rm -rf ~/.misericorde
+   ```
 
 ## ❓ Need Help?
 


### PR DESCRIPTION
**Summary:**  
This pull request simplifies the installation and operation of Miséricorde by:
1. Moving from a system-wide systemd timer to a **user-level systemd timer**, eliminating the need for `sudo` during installation or setup.
2. Updating the installation script to:
   - Write systemd service and timer files to `~/.config/systemd/user/`.
   - Automatically enable and start the user-level timer.
   - Simplify environment variable handling by assuming the script runs in the user's active GUI session.
3. Enhancing the project documentation:
   - Updated the README to reflect the new user-level systemd approach.
   - Added clear instructions for customizing the timer interval and uninstalling the tool.
   - Revised the accompanying HTML page to align with these changes and improve clarity.

**Why this change?**  
The updated approach removes the need for `sudo` or root privileges, improving accessibility and security for end users. It also ensures the tool integrates seamlessly into user environments without system-wide modifications, making it easier to install and maintain.

**Testing:**  
- Verified installation process using the updated `install.sh`.
- Confirmed user-level systemd service and timer function as expected.
- Tested timer customization (e.g., every minute for testing) and ensured proper functionality.